### PR TITLE
Support env PORT and STATUS_CODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then you will get the output like:
 | --- | --- | --- | 
 | `ROOT_PATH` | Environment | Define the root path for this server. Default is `/` |
 | `TARGET` | Environment | Greet to a target. Default is `World` |
+| `PORT` | Environment | Define the server's listening port. Default is `8080` |
+| `STATUS_CODE` | Environment | Define default response status code. If not specified default is `200` |
 | `timeout` | Query Parameter | Add timeout to a request (in seconds). Default is no timeout. |
-| `status_code` | Query Parameter | Return a specific status code. Default is `200` |
-
+| `status_code` | Query Parameter | Return a specific status code. Default value depends on the environment variable `STATUS_CODE`. |

--- a/app.py
+++ b/app.py
@@ -5,10 +5,12 @@ import time
 app = Flask(__name__)
 
 root_path = os.environ.get('ROOT_PATH', '/')
+listener_port = os.environ.get('PORT', 8080)
+default_status_code = os.environ.get('STATUS_CODE', 200)
 
 @app.route(root_path)
 def hello_world():
-    status_code = request.args.get('status_code', 200)
+    status_code = request.args.get('status_code', default_status_code)
     target = os.environ.get('TARGET', 'World')
     timeout = request.args.get('timeout', 0)
     fancy_text = f"""
@@ -44,4 +46,4 @@ def hello_world():
     return fancy_text + request_info, status_code
 
 if __name__ == "__main__":
-    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', "8080")))
+    app.run(debug=True, host='0.0.0.0', port=listener_port)


### PR DESCRIPTION
Extending the sample to allow specifying the following environment variables:
- `PORT`:  define the server's listening port
- `STATUE_CODE`:  define default response status code